### PR TITLE
Support component versioning

### DIFF
--- a/src/main/java/net/stickycode/bootstrap/spring3/Spring3StickyBootstrap.java
+++ b/src/main/java/net/stickycode/bootstrap/spring3/Spring3StickyBootstrap.java
@@ -58,6 +58,7 @@ public class Spring3StickyBootstrap
   public StickyBootstrap scan(String... paths) {
     if (paths.length > 0) {
       ClassPathBeanDefinitionScanner scanner = new ClassPathBeanDefinitionScanner(context, false);
+      scanner.setBeanNameGenerator(new VersionedBeanNameGenerator());
       scanner.setScopeMetadataResolver(new StickyScopeMetadataResolver());
       scanner.addIncludeFilter(new AnnotationTypeFilter(StickyComponent.class));
       scanner.addIncludeFilter(new AnnotationTypeFilter(StickyPlugin.class));

--- a/src/main/java/net/stickycode/bootstrap/spring3/VersionedBeanNameGenerator.java
+++ b/src/main/java/net/stickycode/bootstrap/spring3/VersionedBeanNameGenerator.java
@@ -1,0 +1,34 @@
+package net.stickycode.bootstrap.spring3;
+
+import java.beans.Introspector;
+import java.util.regex.Pattern;
+
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanNameGenerator;
+import org.springframework.util.ClassUtils;
+
+public class VersionedBeanNameGenerator
+    implements BeanNameGenerator {
+
+  private Pattern version = Pattern.compile("v[0-9]+");
+
+  @Override
+  public String generateBeanName(BeanDefinition definition, BeanDefinitionRegistry registry) {
+    return buildVersionedName(definition.getBeanClassName());
+  }
+
+  protected String beanName(String typeName) {
+    return Introspector.decapitalize(ClassUtils.getShortName(typeName));
+  }
+
+  String buildVersionedName(String typeName) {
+    StringBuilder builder = new StringBuilder();
+    String[] components = typeName.split("\\.");
+    for (int i = 0; i < components.length - 1; i++)
+      if (version.matcher(components[i]).matches())
+        builder.append(components[i]).append(".");
+    
+    return builder.append(beanName(typeName)).toString();
+  }
+}

--- a/src/test/java/net/stickycode/bootstrap/spring3/BeanFactoryPostProcessorTest.java
+++ b/src/test/java/net/stickycode/bootstrap/spring3/BeanFactoryPostProcessorTest.java
@@ -53,4 +53,5 @@ public class BeanFactoryPostProcessorTest {
     crank.registerSingleton("bob", new Example(), Example.class);
     crank.inject(this);
   }
+  
 }

--- a/src/test/java/net/stickycode/bootstrap/spring3/VersionedBeanNameTest.java
+++ b/src/test/java/net/stickycode/bootstrap/spring3/VersionedBeanNameTest.java
@@ -1,0 +1,34 @@
+package net.stickycode.bootstrap.spring3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class VersionedBeanNameTest {
+
+  @Test
+  public void names() {
+    assertThat(name("net.stickycode.v1.Bean")).isEqualTo("v1.bean");
+    assertThat(name("net.v2.stickycode.v1.Bean")).isEqualTo("v2.v1.bean");
+    assertThat(name("net.stickycode.Bean")).isEqualTo("bean");
+    assertThat(name("net.vxstickycode.Bean")).isEqualTo("bean");
+    assertThat(name("net.v2stickycode.Bean")).isEqualTo("bean");
+    assertThat(name("net.V2.stickycode.Bean")).isEqualTo("bean");
+    assertThat(name("net.stickycode.v1")).isEqualTo("v1");
+    assertThat(name("net.stickycode.v1212312.Bean")).isEqualTo("v1212312.bean");
+    
+    assertThat(name("net.stickycode.v1.someBean")).isEqualTo("v1.someBean");
+    assertThat(name("net.v2.stickycode.v1.someBean")).isEqualTo("v2.v1.someBean");
+    assertThat(name("net.stickycode.someBean")).isEqualTo("someBean");
+    assertThat(name("net.vxstickycode.someBean")).isEqualTo("someBean");
+    assertThat(name("net.v2stickycode.someBean")).isEqualTo("someBean");
+    assertThat(name("net.V2.stickycode.someBean")).isEqualTo("someBean");
+    assertThat(name("net.stickycode.a1")).isEqualTo("a1");
+    assertThat(name("net.stickycode.v1212312.someBean")).isEqualTo("v1212312.someBean");
+  }
+
+  private String name(String type) {
+    return new VersionedBeanNameGenerator().buildVersionedName(type);
+  }
+
+}


### PR DESCRIPTION
By default components must have unique names base only on class, this is good because things with the same name should not do different things
and as such fail fast. However when you want to version components and run them concurrently its useful that if they exist in a versioned package
then they don't clash, e.g. a.b.v1.C and a.b.v2.C should be OK but a.b.C and a.d.C should not be.